### PR TITLE
Updated regex to include more pr URLs

### DIFF
--- a/contributions/__main__.py
+++ b/contributions/__main__.py
@@ -119,7 +119,7 @@ notes = [note for note_list in notes for note in note_list]
 # Check all lines
 for note in notes:
 #   If line is a pull request url
-    if (match := re.search(r"https://github.com/(\w|\d)+/(\w|\d)+/(pull|issues)/\d+", note)):
+    if (match := re.search(r"https://github.com/[\w\.\d]+/[\w\.\d]+/(issues|pull)/\d+", note)):
         pull_requests.append(match.group())
 
 pull_requests = list(set(pull_requests))


### PR DESCRIPTION
We found a bug that meant that not all contributors' pull requests were output by the script responsible for searching the contributions board.

The issue was with the regex - it could not match URLs where the repo name had a `.` in them (like sec.club); the new regex fixes this.
